### PR TITLE
Fixed performance issues with SdbEntryStringRef

### DIFF
--- a/SDB/Chunk.cs
+++ b/SDB/Chunk.cs
@@ -136,7 +136,7 @@ namespace SDB
 
                         //this provides a means to do easy string lookups based on relative offset
                         var sti = new StringTableEntry(index, Encoding.Unicode.GetString(buff, 0, size).Trim('\0'));
-                        SdbFile.StringTableEntries.Add(sti);
+                        SdbFile.StringTableEntries.Add(sti.Offset, sti);
 
                         //this is the structure itself that defines the strings found in the database
                         var st = new SdbEntryStringTableItem(id1, buff, baseOffset + index - 4);

--- a/SDB/EntryTypes/SdbEntryStringRef.cs
+++ b/SDB/EntryTypes/SdbEntryStringRef.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
 
 namespace SDB.EntryTypes
@@ -29,7 +28,7 @@ namespace SDB.EntryTypes
         private object GetValue()
         {
             var stringOffset = BitConverter.ToInt32(Bytes, 0);
-            return SdbFile.StringTableEntries.SingleOrDefault(t => t.Offset == stringOffset)?.Value;
+            return SdbFile.StringTableEntries[stringOffset].Value;
         }
 
         public override string ToString()

--- a/SDB/SdbFile.cs
+++ b/SDB/SdbFile.cs
@@ -368,7 +368,7 @@ namespace SDB
 
         public List<ISdbEntry> Children { get; }
 
-        public static List<StringTableEntry> StringTableEntries { get; } = new List<StringTableEntry>();
+        public static Dictionary<int, StringTableEntry> StringTableEntries { get; } = new Dictionary<int, StringTableEntry>();
 
         public static Dictionary<TagValue, int> Metrics { get; } = new Dictionary<TagValue, int>();
 


### PR DESCRIPTION
Big SDBs (like sysmain) take too much time to load. All this time is spent looking up strings in the StringTableEntries.

This commit replaces linear search with a map.